### PR TITLE
package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cython
 hyperopt==0.1.2
 pyyaml
 numpy==1.16.4
-torch>=1.2.0
+torch==1.5.0
 torchvision>=0.4.0
 fvcore
 matplotlib
@@ -18,4 +18,4 @@ lightgbm
 ngboost==0.3.7
 xgboost
 -e git://github.com/automl/pybnn.git@master#egg=pybnn
-pyro-ppl
+pyro-ppl==1.4.0


### PR DESCRIPTION
https://pypi.org/project/pyro-ppl/#history has a new release that automatically installs PyTorch-1.7.1, which then conflicts with some other packages.