### PR TITLE
fixed config not read issue

### DIFF
--- a/naslib/utils/utils.py
+++ b/naslib/utils/utils.py
@@ -139,6 +139,9 @@ def get_config_from_args(args=None, config_type='nas'):
 
     if args is None:
         args = parse_args()
+    else:
+        parser = default_argument_parser()
+        args = parser.parse_args(args)
     print(args)
     logger.info("Command line args: {}".format(args))
 
@@ -164,7 +167,7 @@ def get_config_from_args(args=None, config_type='nas'):
         config.seed = args.seed
 
     # load config file
-    config.merge_from_file(args.config_file)
+    config.merge_from_file(os.path.join(get_project_root(),args.config_file))
     config.merge_from_list(args.opts)
 
     # prepare the output directories


### PR DESCRIPTION
Issue: when called get_config_from_args with ''--config-file" option it does not load that config file. 
Solution: I noticed that args variable was supposed to be parsed but wasn't so i created the parser and parsed it. at line 170 I was getting filenotfound error so I added project root with the config_file which fixed the issue.