### PR TITLE
Fix graph.reset_weights()

### DIFF
--- a/naslib/search_spaces/core/graph.py
+++ b/naslib/search_spaces/core/graph.py
@@ -727,7 +727,8 @@ class Graph(torch.nn.Module, nx.DiGraph):
         """
 
         def weight_reset(m):
-            if isinstance(m, torch.nn.Conv2d) or isinstance(m, torch.nn.Linear):
+            reset_parameters = getattr(m, "reset_parameters", None)
+            if callable(reset_parameters):
                 m.reset_parameters()
 
         if inplace:


### PR DESCRIPTION
- Only weights of torch.nn.Conv2d and torch.nn.Linear were being reset
- Now calls the reset_parameters() method if the module has it