### PR TITLE
Fix testing errors

### DIFF
--- a/naslib/search_spaces/hierarchical/graph.py
+++ b/naslib/search_spaces/hierarchical/graph.py
@@ -74,7 +74,7 @@ class HierarchicalSearchSpace(Graph):
         self.add_nodes_from([i for i in range(1, 9)])
         self.add_edges_from([(i, i + 1) for i in range(1, 8)])
 
-        self.edges[1, 2].set("op", ops.Stem(16))
+        self.edges[1, 2].set("op", ops.Stem(C_out=16))
         self.edges[2, 3].set("op", cells[0])
         self.edges[3, 4].set(
             "op", ops.SepConv(16, 32, kernel_size=3, stride=2, padding=1)
@@ -117,7 +117,7 @@ class HierarchicalSearchSpace(Graph):
                     single_instances=False,
                 )
 
-        self.edges[1, 2].set("op", ops.Stem(channels[0]))
+        self.edges[1, 2].set("op", ops.Stem(C_out=channels[0]))
         self.edges[2, 3].set("op", cells[0].copy())
         self.edges[3, 4].set(
             "op",
@@ -191,7 +191,7 @@ class HierarchicalSearchSpace(Graph):
     #                 single_instances=False
     #             )
 
-    #     self.edges[1, 2].set('op', ops.Stem(channels[0]))
+    #     self.edges[1, 2].set('op', ops.Stem(C_out=channels[0]))
     #     self.edges[2, 3].set('op', cells[0].copy())
     #     self.edges[3, 4].set('op', ops.SepConv(channels[0], channels[1], kernel_size=3, stride=2, padding=1))
     #     self.edges[4, 5].set('op', cells[1].copy())
@@ -400,7 +400,7 @@ class LiuFinalArch(HierarchicalSearchSpace):
         self.add_nodes_from([i for i in range(1, 15)])
         self.add_edges_from([(i, i + 1) for i in range(1, 14)])
 
-        self.edges[1, 2].set("op", ops.Stem(channels[0]))
+        self.edges[1, 2].set("op", ops.Stem(C_out=channels[0]))
         self.edges[2, 3].set("op", cells[0].copy())
         self.edges[3, 4].set(
             "op",

--- a/naslib/search_spaces/simple_cell/graph.py
+++ b/naslib/search_spaces/simple_cell/graph.py
@@ -139,7 +139,7 @@ class SimpleCellSearchSpace(Graph):
 
         # Compile the ops
         self.edges[1, 2].set(
-            "op", ops.Stem(channels[0])
+            "op", ops.Stem(C_out=channels[0])
         )  # we can also set a compiled op. Will be ignored by compile()
 
         def set_channels(edge, C):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ xgboost==1.4.2
 emcee==3.1.0
 pybnn==0.0.5
 grakel==0.1.8
-pyro-ppl==1.6.0
+pyro-ppl==1.8.4
 
 # additional from setup.py prev
 tqdm==4.61.1

--- a/tests/test_nb301_search_space.py
+++ b/tests/test_nb301_search_space.py
@@ -117,7 +117,7 @@ class NasBench301SearchSpaceTest(unittest.TestCase):
 
         graph(torch.randn(3, 3, 32, 32))
         aux_out = graph.auxiliary_logits()
-        self.assertEqual(aux_out.shape, (3, 512, 8, 8))
+        self.assertEqual(aux_out.shape, (3, 256, 8, 8))
 
     def test_forward_pass_aux_head_eval(self):
         graph = create_model()


### PR DESCRIPTION
Fix for the following errors:
- compatibility issue between Pyro 1.6.0 and PyTorch 2.0
- mismatch of auxiliary output shapes (NB301)
- mismatch of channel sizes using the `Stem()` operation